### PR TITLE
Update Erlang minor version

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -25,7 +25,7 @@ jobs:
       uses: erlef/setup-beam@v1
       with:
         elixir-version: 1.12.0
-        otp-version: 24.0
+        otp-version: 24.0.2
 
     - name: Cache elixir deps
       uses: actions/cache@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.2.0
 elixir 1.12.0
-erlang 24.0
+erlang 24.0.2

--- a/api/elixir_buildpack.config
+++ b/api/elixir_buildpack.config
@@ -1,2 +1,2 @@
-erlang_version=OTP-24.0
+erlang_version=OTP-24.0.2
 elixir_version=1.12.0


### PR DESCRIPTION
Why:
* Due to an issue with the installation of Erlang 24.0 in MacOS
* https://github.com/erlang/otp/issues/4821

How:
* Changing the Erlang version from `24.0` to `24.0.2`
