### PR TITLE
Fix secret line breaks in show room

### DIFF
--- a/frontend/src/routes/[room].svelte
+++ b/frontend/src/routes/[room].svelte
@@ -64,7 +64,9 @@
     <p class="w-4/5 text-center mb-10">
       Your secret was revealed and permanently deleted from the system 🔥
     </p>
-    <div class="border border-gray-300 rounded-md p-4 w-4/5 cursor-not-allowed break-words">
+    <div
+      class="border border-gray-300 rounded-md p-4 w-4/5 cursor-not-allowed break-words whitespace-pre-wrap"
+    >
       {decryptedSecret}
     </div>
 


### PR DESCRIPTION
Why:
 - `\n` weren't being rendered as supposed and the secrets lost formatting.

How:
 - Added `whitespace-pre` in the secret div.