### PR TITLE
Simplify redis script; fix ci tests

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -45,6 +45,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
+        sudo apt install inotify-tools
         mix deps.get
 
     - name: Linting

--- a/api/lib/secrets_api/secrets.ex
+++ b/api/lib/secrets_api/secrets.ex
@@ -8,19 +8,12 @@ defmodule SecretsApi.Secrets do
 
   require Logger
 
-  @store_lua_script """
-    redis.call('set', KEYS[1], KEYS[2])
-    redis.call('expire', KEYS[1], 3600)
-
-    return
-  """
-
   @spec store_secret(any) ::
           {:error, charlist()} | {:ok, binary}
   def store_secret(secret) do
     room_id = generate_room_id()
 
-    case Redix.command(["EVAL", @store_lua_script, 2, room_id, secret]) do
+    case Redix.command(["SET", room_id, secret, "EX", "3600", "NX"]) do
       {:ok, _} ->
         {:ok, room_id}
 


### PR DESCRIPTION
Why?
We can do what the lua script was doing in a single atomic operation
The ci tests weren't running because off missing dependencies 

How?
SET with EX and NX performs a few different things (checking existence, setting the value, setting the expiry) all in one atomic operation
Add the missing dependency to the ci yaml