### PR TITLE
Add ability to set the expiry time of a secret

### DIFF
--- a/api/config/config.exs
+++ b/api/config/config.exs
@@ -22,6 +22,7 @@ config :logger, :console,
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
+config :phoenix, :filter_parameters, ["secret"]
 
 # Configures Redis
 redis_url = System.get_env("REDIS_URL") || "redis://localhost:6379"

--- a/api/lib/secrets_api/secrets.ex
+++ b/api/lib/secrets_api/secrets.ex
@@ -8,12 +8,12 @@ defmodule SecretsApi.Secrets do
 
   require Logger
 
-  @spec store_secret(any) ::
+  @spec store_secret(any, any) ::
           {:error, charlist()} | {:ok, binary}
-  def store_secret(secret) do
+  def store_secret(secret, expiry \\ 3600) do
     room_id = generate_room_id()
 
-    case Redix.command(["SET", room_id, secret, "EX", "3600", "NX"]) do
+    case Redix.command(["SET", room_id, secret, "EX", expiry, "NX"]) do
       {:ok, _} ->
         {:ok, room_id}
 

--- a/api/lib/secrets_api_web/controllers/secrets_controller.ex
+++ b/api/lib/secrets_api_web/controllers/secrets_controller.ex
@@ -5,6 +5,12 @@ defmodule SecretsApiWeb.SecretsController do
 
   action_fallback SecretsApiWeb.ErrorController
 
+  def create(conn, %{"secret" => secret, "expiry" => expiry}) do
+    with {:ok, room_id} <- Secrets.store_secret(secret, expiry) do
+      json(conn, %{room_id: room_id})
+    end
+  end
+
   def create(conn, %{"secret" => secret}) do
     with {:ok, room_id} <- Secrets.store_secret(secret) do
       json(conn, %{room_id: room_id})

--- a/api/test/secrets_api_web/controllers/secrets_controller_test.exs
+++ b/api/test/secrets_api_web/controllers/secrets_controller_test.exs
@@ -78,6 +78,18 @@ defmodule SecretsApiWeb.SecretsControllerTests do
                "room_id" => _secret
              } = json_response(conn, 200)
     end
+
+    test "accepts an expiry time", %{conn: conn} do
+      secret = "some secret"
+      expiry = 3600
+
+      conn =
+        post(conn, Routes.secrets_path(conn, :create), %{"secret" => secret, "expiry" => expiry})
+
+      assert %{
+               "room_id" => _secret
+             } = json_response(conn, 200)
+    end
   end
 
   describe "delete" do

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,7 +5,7 @@ export async function createSecret({
   expiry
 }: {
   secret: string;
-  expiry: string;
+  expiry: number;
 }): Promise<string> {
   const response = await fetch(`${API_URL}/api/secrets`, {
     method: 'POST',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,15 @@
 const API_URL = import.meta.env.VITE_API_URL;
 
-export async function createSecret(secret: string): Promise<string> {
+export async function createSecret({
+  secret,
+  expiry
+}: {
+  secret: string;
+  expiry: string;
+}): Promise<string> {
   const response = await fetch(`${API_URL}/api/secrets`, {
     method: 'POST',
-    body: JSON.stringify({ secret }),
+    body: JSON.stringify({ secret, expiry }),
     headers: {
       'content-type': 'application/json'
     }

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -23,7 +23,7 @@
       submitting = true;
       encryptionKey = generatePassphrase();
       encryptedText = await encryptData(textToEncrypt, encryptionKey);
-      roomId = await createSecret({ secret: encryptedText, expiry });
+      roomId = await createSecret({ secret: encryptedText, expiry: Number(expiry) });
       sharingUrl = `${location.protocol}//${location.host}/${roomId}#${encryptionKey}`;
       submitting = false;
     } catch (_) {

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -15,6 +15,7 @@
   let submitting: boolean;
   let deleting: boolean;
   let roomId: string;
+  let expiry: string;
 
   async function handleClick(event: { preventDefault: () => void }) {
     try {
@@ -22,7 +23,7 @@
       submitting = true;
       encryptionKey = generatePassphrase();
       encryptedText = await encryptData(textToEncrypt, encryptionKey);
-      roomId = await createSecret(encryptedText);
+      roomId = await createSecret({ secret: encryptedText, expiry });
       sharingUrl = `${location.protocol}//${location.host}/${roomId}#${encryptionKey}`;
       submitting = false;
     } catch (_) {
@@ -79,6 +80,29 @@
         placeholder="Your information..."
         bind:value={textToEncrypt}
       />
+
+      <div class="w-full mx-8 mt-8">
+        <p class="text-lg">Secret lifetime</p>
+
+        <div class="flex">
+          <p>
+            This link is valid for
+            <select
+              name="expiry"
+              class="border-gray-400 border-2 p-2 rounded cursor-pointer"
+              bind:value={expiry}
+            >
+              <option value="900">15 min</option>
+              <option value="1800">30 min</option>
+              <option value="3600">1 hour</option>
+              <option value="21600">6 hours </option>
+              <option value="86400">1 day</option>
+              <option value="604800">7 days</option>
+            </select>
+            or until revealed. After this date, it will be destroyed.
+          </p>
+        </div>
+      </div>
 
       <div class="mt-10">
         {#if submitting}


### PR DESCRIPTION
Add an extra param to the API to pass in the expiry value in seconds.

And also add `secret` to the filtered params list so we never log that info, even if it's encrypted.