### PR TITLE
Fix bin/setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -31,10 +31,6 @@ else
   asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git 2>/dev/null
   set -e
 
-  printf "Importing nodejs release team keyring... "
-  bin/helpers/import-nodejs-keys
-  echo "Done!"
-
   asdf install
 fi
 


### PR DESCRIPTION
Why:
- The bin/setup script was causing an error due to trying to import
  the node keyring. This was recently changed to [use node-build](https://github.com/asdf-vm/asdf-nodejs#node-build-advanced-variations)
  instead of importing the keyring.
How:
- Removing the lines that were importing the keyring.